### PR TITLE
feat(styles): improve accessiblity in about page

### DIFF
--- a/src/app/components/ExtendedInfo/ExtendedInfo.tsx
+++ b/src/app/components/ExtendedInfo/ExtendedInfo.tsx
@@ -7,11 +7,11 @@ export default function ExtendedInfo() {
     <section className="p-3 md:px-5 lg:px-10">
       <p className="text-balance text-center">
         {t('introduction')}
-        <strong className="text-primary-color-300">
+        <strong className="text-primary-color-400">
           {t('experienceInYears') + ' '}
         </strong>
         {t('experienceComplement')}
-        <strong className="text-primary-color-300">
+        <strong className="text-primary-color-400">
           {' '}
           {t('englishLevel')}
         </strong>{' '}


### PR DESCRIPTION
# Improving accessibility in about page. 

Change text color in extended experience info

## Before
![image](https://github.com/user-attachments/assets/d11afe3d-3831-4bed-910f-b2c1ef96c79e)


## After
![image](https://github.com/user-attachments/assets/739e45f2-1237-45a9-8d8a-c5808fcf2720)

